### PR TITLE
Update link to Guardianstats

### DIFF
--- a/src/components/characterDisplay/CharacterLinks.tsx
+++ b/src/components/characterDisplay/CharacterLinks.tsx
@@ -71,7 +71,7 @@ export const CharacterLinks = ({
             { text: "D2 Checklist", tags: ["d2checklist"] }
           )}
           {link(
-            `https://guardianstats.com/inspect/${membershipType}/${membershipId}`,
+            `https://guardianstats.com/profile/${membershipId}`,
             { text: "Guardianstats", tags: ["guardianstats"] }
           )}
           {link(


### PR DESCRIPTION
The old link now leads to a 404, seems like they've moved their inspect endpoint to /profile/membershipId and doesn't have the membershipType specified in the URL anymore.

Examples:

[My Xbox Profile](https://guardianstats.com/profile/4611686018448219656)

[My Steam Profile](https://guardianstats.com/profile/4611686018467557824)

However, using Destiny Power Bars link, it tries to go to https://guardianstats.com/inspect/3/4611686018467557824 which is what leads to a 404.